### PR TITLE
refactor: avoid verbose kratos logs 

### DIFF
--- a/kratos/values.yaml
+++ b/kratos/values.yaml
@@ -26,6 +26,11 @@ kratos:
     serve:
       public:
         base_url: https://${host}
+        request_log:
+          disable_for_health: true
+      admin:
+        request_log:
+          disable_for_health: true
 
     selfservice:
       default_browser_return_url: https://${domain}/


### PR DESCRIPTION
If you have seen kratos logs they are like the following:
```
time=2023-04-07T18:48:43Z level=info msg=started handling request http_request=map[headers:map[accept:*/* connection:close user-agent:kube-probe/1.23] host:10.4.0.3:4434 method:GET path:/admin/health/ready query:<nil> remote:10.4.0.1:59018 scheme:http]
time=2023-04-07T18:48:43Z level=info msg=started handling request http_request=map[headers:map[accept:*/* connection:close user-agent:kube-probe/1.23] host:10.4.0.3:4434 method:GET path:/admin/health/alive query:<nil> remote:10.4.0.1:59020 scheme:http]
time=2023-04-07T18:48:43Z level=info msg=completed handling request http_request=map[headers:map[accept:
...
```
and a lot of them repeated ad infinitum. These are just health checks.
So, when you have an actual user request and are trying to debug it is quite hard to find the right logs.
This PR changes it in order to not log the health checks any more.

~WARNING: it may be tricky, sometimes the health checks can indeed give us essential information, above all when we have 503 service unavailable. These cases are rare but if they happen we have to locally revert this changes while debugging. All in all it is better though to not have so much logs.~
edit: not to worry: error continues to the logged