### PR TITLE
feat(enmeshed): deploy own mongodb instead of builtin dev db

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         module:
+          - enmeshed
           - hydra
           - ingress
           - ingress-nginx

--- a/enmeshed/main.tf
+++ b/enmeshed/main.tf
@@ -36,6 +36,7 @@ resource "helm_release" "enmeshed_deployment" {
     templatefile(
       "${path.module}/values.yaml",
       {
+        mongodb_uri            = "mongodb://root:${random_password.mongodb_root_password.result}@mongodb:27017/?authSource=admin&readPreference=primary&ssl=false"
         platform_client_id     = var.platform_client_id
         platform_client_secret = var.platform_client_secret
         transport_base_url     = var.transport_base_url
@@ -44,4 +45,26 @@ resource "helm_release" "enmeshed_deployment" {
       }
     )
   ]
+}
+
+resource "helm_release" "database" {
+  name       = "mongodb"
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "mongodb"
+  version    = "14.0.12"
+  namespace  = var.namespace
+
+  values = [
+    templatefile(
+      "${path.module}/values-mongodb.yaml",
+      {
+        mongodb_root_password = random_password.mongodb_root_password.result
+    })
+  ]
+}
+
+
+resource "random_password" "mongodb_root_password" {
+  length  = 32
+  special = false
 }

--- a/enmeshed/values-mongodb.yaml
+++ b/enmeshed/values-mongodb.yaml
@@ -1,0 +1,7 @@
+image:
+  tag: 7.0.2
+architecture: standalone
+global:
+  storageClass: standard
+auth:
+  rootPassword: ${mongodb_root_password}

--- a/enmeshed/values.yaml
+++ b/enmeshed/values.yaml
@@ -1,42 +1,37 @@
 config:
   database:
-    connectionString: "mongodb://localhost:27017"
+    connectionString: ${mongodb_uri}
 
-  transportLibrary: 
+  transportLibrary:
     baseUrl: ${transport_base_url}
     platformClientId: ${platform_client_id}
     platformClientSecret: ${platform_client_secret}
 
-  infrastructure: 
-    httpServer: 
+  infrastructure:
+    httpServer:
       enabled: true
-      cors: 
+      cors:
         origin: false
       apiKey: ${api_key}
 
-  modules: 
-    sync: 
+  modules:
+    sync:
       enabled: true
       interval: 5
-    autoAcceptRelationshipCreationChanges: 
+    autoAcceptRelationshipCreationChanges:
       enabled: false
-      responseContent: 
-    coreHttpApi: 
+      responseContent:
+    coreHttpApi:
       enabled: true
-      docs: 
+      docs:
         enabled: false
-    webhooksV2: 
+    webhooksV2:
       enabled: true
-      webhooks:       
+      webhooks:
         - triggers:
-          - transport.messageReceived
-          target: 
+            - transport.messageReceived
+          target:
             url: ${api_url}/enmeshed/webhook
-            headers: 
+            headers:
               X-API-KEY: ${api_key}
             publishInterval: 5
-
-pod:
-  ferretdb:
-    enabled: true
-    image: all-in-one


### PR DESCRIPTION
Somehow the container ferretdb, provided by the enmeshed helm chart,
was refusing connection to the connector container. Sometimes it healed
by itself, but then we had caching problem (since the db was also
deleted). Sometimes it didn't even healed by itself, so that we needed
to delete the pod.

Therefore, tt is more secure to have an extra mongodb instance.
